### PR TITLE
Remove outdated advice concerning rule updates

### DIFF
--- a/docs/content/operations/rule-configuration.md
+++ b/docs/content/operations/rule-configuration.md
@@ -33,8 +33,6 @@ The Coordinator loads a set of rules from the metadata storage. Rules may be spe
 
 Note: It is recommended that the Coordinator console is used to configure rules. However, the Coordinator process does have HTTP endpoints to programmatically configure rules.
 
-When a rule is updated, the change may not be reflected until the next time the Coordinator runs. This will be fixed in the near future.
-
 Load Rules
 ----------
 


### PR DESCRIPTION
When updating rules, I see my results immediately and do not need to restart Coordinator to see this reflected. Also, this line is [almost 4 years old](https://github.com/apache/incubator-druid/commit/4575c5378c0107eaa86e03f3d0358473efc63cbc), so is likely referring to a fix that occurred sometime in the last 4 years.